### PR TITLE
Add a supervision tree for WebsocketWorker and ArchiveWorker. 

### DIFF
--- a/lib/aprsme/application.ex
+++ b/lib/aprsme/application.ex
@@ -8,14 +8,17 @@ defmodule Aprsme.Application do
 
     # Define workers and child supervisors to be supervised
     children = [
-      # Start the Ecto repository
-      supervisor(Aprsme.Repo, []),
-      # Start the endpoint when the application starts
-      supervisor(AprsmeWeb.Endpoint, []),
-      worker(Aprsme.WebsocketWorker, []),
-      worker(Aprsme.ArchiveWorker, [])
       # Start your own worker by calling: Aprsme.Worker.start_link(arg1, arg2, arg3)
       # worker(Aprsme.Worker, [arg1, arg2, arg3]),
+
+      # Start the Ecto repository
+      supervisor(Aprsme.Repo, []),
+
+      # Start the endpoint when the application starts
+      supervisor(AprsmeWeb.Endpoint, []),
+
+      # Supervision tree for incoming packets from RabbitMQ
+      supervisor(Aprsme.IncomingPacketSupervisor, [])
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/aprsme/incoming_packet_supervisor.ex
+++ b/lib/aprsme/incoming_packet_supervisor.ex
@@ -1,0 +1,20 @@
+defmodule Aprsme.IncomingPacketSupervisor do
+  use Supervisor
+
+  # public API 
+  def start_link() do
+    Supervisor.start_link(__MODULE__, [], restart: :permanent, name: __MODULE__)
+  end
+
+  # callbacks
+  def init(_) do
+    children = [
+      worker(Aprsme.WebsocketWorker, []),
+      worker(Aprsme.ArchiveWorker, []),
+    ]
+
+    opts = [strategy: :one_for_one]
+
+    supervise(children, opts)
+  end
+end

--- a/lib/aprsme/websocket_worker.ex
+++ b/lib/aprsme/websocket_worker.ex
@@ -41,23 +41,6 @@ defmodule Aprsme.WebsocketWorker do
       {:noreply, state}
     end
 
-    # log("Opening channel")
-    # {:ok, channel} = AMQP.Channel.open(connection)
-
-    # log("Declaring exchange...")
-
-    # log("Declaring queue #{@queue_name}")
-    # {:ok, _queue} = AMQP.Queue.declare(channel, @queue_name, durable: false)
-
-    # log("Binding #{@queue_name} to source #{@source_exchange_name}")
-    # :ok = AMQP.Queue.bind(channel, @queue_name, @source_exchange_name, routing_key: "#")
-
-    # log("basic.consume...")
-    # AMQP.Basic.consume(channel, @queue_name, nil, no_ack: true)
-
-    # log("waiting for messages")
-
-    # {:ok, state}
   end
 
   # change to handle_info

--- a/lib/aprsme/websocket_worker.ex
+++ b/lib/aprsme/websocket_worker.ex
@@ -7,11 +7,16 @@ defmodule Aprsme.WebsocketWorker do
 
   def start_link(args \\ []) do
     IO.puts("#{__MODULE__}.start_link()")
-    GenServer.start_link(__MODULE__, [], args)
+    GenServer.start_link(__MODULE__, [], name: :websocket_worker)
   end
 
   def init(state \\ []) do
-    IO.puts("#{__MODULE__}.init()")
+    Process.send_after(self(), :connect, 5000)
+    {:ok, state}
+  end
+
+  def handle_info(:connect, state) do
+    IO.puts("#{__MODULE__}:: Attempting to connect to RabbitMQ")
 
     log("rabbitmq_url: #{rabbitmq_url()}")
 
@@ -31,9 +36,9 @@ defmodule Aprsme.WebsocketWorker do
       log("basic.consume...")
       AMQP.Basic.consume(channel, @queue_name, nil, no_ack: true)
 
-      log("waiting for messages")
+      log("#{__MODULE__}: Waiting for messages")
 
-      {:ok, state}
+      {:noreply, state}
     end
 
     # log("Opening channel")


### PR DESCRIPTION
Change structure of both workers to attempt to connect to RMQ after a small delay after starting up, or crash. Fixes #5 