### PR TITLE
Kubernetes manifest edits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ data/geoip
 data/certbot
 .env
 
+k8s/_delete.sh

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -9,7 +9,9 @@ Configure a namespaced context for kubectl: (example using docker w/ kubernetes)
 (Swap out cluster/user for the existing from the result of kubectl config view)  
 `kubectl config view`  
 `kubectl config current-context`  
-`kubectl config set-context dev --namespace=aprsme-dev \\n--cluster=docker-desktop \\n--user=docker-desktop`  
+`kubectl config set-context dev --namespace=aprsme-dev \`  
+`--cluster=docker-desktop \`  
+`--user=docker-desktop`  
 `kubectl config view`  
 `kubectl config use-context dev`
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,39 @@
+# Kubernetes deployment
+
+## To configure:
+
+Create namespace aprsme-dev:  
+`kubectl apply -f ./namespace.yaml`
+
+Configure a namespaced context for kubectl: (example using docker w/ kubernetes)  
+(Swap out cluster/user for the existing from the result of kubectl config view)  
+`kubectl config view`  
+`kubectl config current-context`  
+`kubectl config set-context dev --namespace=aprsme-dev \\n--cluster=docker-desktop \\n--user=docker-desktop`  
+`kubectl config view`  
+`kubectl config use-context dev`
+
+Create services  
+`kubectl apply -f ./services.yaml`
+
+Check services are configured  
+`kubectl get svc`
+
+Create persistant storage volumes  
+`kubectl apply -f ./storage.yaml`
+
+Check storage is requested and bound (re-run until complete)  
+`kubectl get pvc`
+
+Create deployments  
+`kubectl apply -f ./deployments.yaml`
+
+Check pod status  
+`kubectl get pod`
+
+Configure Ingress (TBC)
+
+
+To quickly delete all resources:  
+`kubectl delete aprsme-dev`  
+This will delete the namespace and everything contained in it.

--- a/k8s/app-deployment.yaml
+++ b/k8s/app-deployment.yaml
@@ -7,11 +7,15 @@ metadata:
   creationTimestamp: null
   labels:
     io.kompose.service: app
+    app: aprsme
   name: app
 spec:
   replicas: 1
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      app: aprsme
   template:
     metadata:
       annotations:
@@ -21,6 +25,7 @@ spec:
       labels:
         io.kompose.network/app-tier: "true"
         io.kompose.service: app
+        app: aprsme
     spec:
       containers:
       - env:

--- a/k8s/aprs-slurp-deployment.yaml
+++ b/k8s/aprs-slurp-deployment.yaml
@@ -7,10 +7,14 @@ metadata:
   creationTimestamp: null
   labels:
     io.kompose.service: aprs-slurp
+    app: aprs-slurp
   name: aprs-slurp
 spec:
   replicas: 1
   strategy: {}
+  selector:
+    matchLabels:
+      app: aprs-slurp
   template:
     metadata:
       annotations:
@@ -20,6 +24,7 @@ spec:
       labels:
         io.kompose.network/app-tier: "true"
         io.kompose.service: aprs-slurp
+        app: aprs-slurp
     spec:
       containers:
       - env:

--- a/k8s/certbot-deployment.yaml
+++ b/k8s/certbot-deployment.yaml
@@ -7,11 +7,15 @@ metadata:
   creationTimestamp: null
   labels:
     io.kompose.service: certbot
+    app: certbot
   name: certbot
 spec:
   replicas: 1
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      app: certbot
   template:
     metadata:
       annotations:
@@ -20,6 +24,7 @@ spec:
       creationTimestamp: null
       labels:
         io.kompose.service: certbot
+        app: certbot
     spec:
       containers:
       - command:

--- a/k8s/deployments.yaml
+++ b/k8s/deployments.yaml
@@ -1,0 +1,403 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ./docker-compose.yml
+    kompose.version: 1.20.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: app
+    app: aprsme
+  name: app
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: aprsme
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f ./docker-compose.yml
+        kompose.version: 1.20.0 ()
+      creationTimestamp: null
+      labels:
+        io.kompose.network/app-tier: "true"
+        io.kompose.service: app
+        app: aprsme
+    spec:
+      containers:
+      - env:
+        - name: DATABASE_URL
+          value: postgresql://postgres:2LRfvZdwWshXUFXFEJvBkegd@postgres/aprsme
+        - name: ERL_CRASH_DUMP_BYTES
+          value: "0"
+        - name: HOSTNAME
+          value: aprs.me
+        - name: PORT
+          value: "4000"
+        - name: RABBITMQ_URL
+          value: amqp://user:bitnami@rabbitmq:5672/aprs
+        - name: SECRET_KEY_BASE
+          value: hZN8qjZYwwI2rIXtXwbCJoFl/xxxW/VSi+4Fd/ZvP4XAJiLUdKG86dF9Pu0tnrMm
+        image: aprsme/app:latest
+        name: aprsme-app
+        ports:
+        - containerPort: 4000
+        resources: {}
+        volumeMounts:
+        - mountPath: /data/geoip
+          name: app-claim0
+      restartPolicy: Always
+      volumes:
+      - name: app-claim0
+        persistentVolumeClaim:
+          claimName: app-claim0
+status: {}
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ./docker-compose.yml
+    kompose.version: 1.20.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: aprs-slurp
+    app: aprs-slurp
+  name: aprs-slurp
+spec:
+  replicas: 1
+  strategy: {}
+  selector:
+    matchLabels:
+      app: aprs-slurp
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f ./docker-compose.yml
+        kompose.version: 1.20.0 ()
+      creationTimestamp: null
+      labels:
+        io.kompose.network/app-tier: "true"
+        io.kompose.service: aprs-slurp
+        app: aprs-slurp
+    spec:
+      containers:
+      - env:
+        - name: APRS_SERVER
+          value: g.vntx.net:10152
+        - name: APRS_USERNAME
+          value: APRSME-99
+        - name: RABBITMQ_HOST
+          value: rabbitmq
+        - name: RABBITMQ_PASSWORD
+          value: bitnami
+        - name: RABBITMQ_PORT
+          value: "5672"
+        - name: RABBITMQ_USERNAME
+          value: user
+        - name: RABBITMQ_VHOST
+          value: aprs
+        image: aprsme/aprs_slurp:latest
+        name: aprs-slurp
+        resources: {}
+      restartPolicy: Always
+status: {}
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ./docker-compose.yml
+    kompose.version: 1.20.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: certbot
+    app: certbot
+  name: certbot
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: certbot
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f ./docker-compose.yml
+        kompose.version: 1.20.0 ()
+      creationTimestamp: null
+      labels:
+        io.kompose.service: certbot
+        app: certbot
+    spec:
+      containers:
+      - command:
+        - /bin/sh
+        - -c
+        - trap exit TERM; while :; do certbot renew; sleep 12h & wait ${!}; done;
+        image: certbot/certbot
+        name: certbot
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/letsencrypt
+          name: certbot-claim0
+        - mountPath: /var/www/certbot
+          name: certbot-claim1
+      restartPolicy: Always
+      volumes:
+      - name: certbot-claim0
+        persistentVolumeClaim:
+          claimName: certbot-claim0
+      - name: certbot-claim1
+        persistentVolumeClaim:
+          claimName: certbot-claim1
+status: {}
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ./docker-compose.yml
+    kompose.version: 1.20.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: geoipupdate
+    app: geoipupdate
+  name: geoipupdate
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: geoipupdate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f ./docker-compose.yml
+        kompose.version: 1.20.0 ()
+      creationTimestamp: null
+      labels:
+        io.kompose.network/app-tier: "true"
+        io.kompose.service: geoipupdate
+        app: geoipupdate
+    spec:
+      containers:
+      - env:
+        - name: ACCOUNT_ID
+          value: "165665"
+        - name: GEOIP_DB_DIR
+          value: /opt/geoip
+        - name: LICENSE_KEY
+          value: ZTErFxgJ2JKy3ZvJ
+        image: tkrs/maxmind-geoipupdate:latest
+        name: geoipupdate
+        resources: {}
+        volumeMounts:
+        - mountPath: /opt/geoip
+          name: geoipupdate-claim0
+      restartPolicy: Always
+      volumes:
+      - name: geoipupdate-claim0
+        persistentVolumeClaim:
+          claimName: geoipupdate-claim0
+status: {}
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ./docker-compose.yml
+    kompose.version: 1.20.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: nginx
+    app: nginx
+  name: nginx
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f ./docker-compose.yml
+        kompose.version: 1.20.0 ()
+      creationTimestamp: null
+      labels:
+        io.kompose.network/app-tier: "true"
+        io.kompose.service: nginx
+        app: nginx
+    spec:
+      containers:
+      - image: nginx:1.17.7-alpine
+        name: nginx
+        ports:
+        - containerPort: 80
+        - containerPort: 443
+        resources: {}
+        volumeMounts:
+        - mountPath: /etc/nginx/conf.d
+          name: nginx-claim0
+        - mountPath: /etc/letsencrypt
+          name: nginx-claim1
+        - mountPath: /var/www/certbot
+          name: nginx-claim2
+      restartPolicy: Always
+      volumes:
+      - name: nginx-claim0
+        persistentVolumeClaim:
+          claimName: nginx-claim0
+      - name: nginx-claim1
+        persistentVolumeClaim:
+          claimName: nginx-claim1
+      - name: nginx-claim2
+        persistentVolumeClaim:
+          claimName: nginx-claim2
+status: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ./docker-compose.yml
+    kompose.version: 1.20.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: postgres
+    app: postgres
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f ./docker-compose.yml
+        kompose.version: 1.20.0 ()
+      creationTimestamp: null
+      labels:
+        io.kompose.network/app-tier: "true"
+        io.kompose.service: postgres
+        app: postgres
+    spec:
+      containers:
+      - env:
+        - name: POSTGRES_DB
+          value: aprsme
+        - name: POSTGRES_PASSWORD
+          value: 2LRfvZdwWshXUFXFEJvBkegd
+        image: mdillon/postgis:11-alpine
+        name: postgres
+        ports:
+        - containerPort: 5432
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: postgres-claim0
+      restartPolicy: Always
+      volumes:
+      - name: postgres-claim0
+        persistentVolumeClaim:
+          claimName: postgres-claim0
+status: {}
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ./docker-compose.yml
+    kompose.version: 1.20.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: rabbitmq
+    app: rabbitmq
+  name: rabbitmq
+spec:
+  replicas: 1
+  strategy: {}
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f ./docker-compose.yml
+        kompose.version: 1.20.0 ()
+      creationTimestamp: null
+      labels:
+        io.kompose.network/app-tier: "true"
+        io.kompose.service: rabbitmq
+        app: rabbitmq
+    spec:
+      containers:
+      - env:
+        - name: RABBITMQ_VHOST
+          value: aprs
+        image: bitnami/rabbitmq:latest
+        name: rabbitmq
+        ports:
+        - containerPort: 15672
+        - containerPort: 5672
+        resources: {}
+      restartPolicy: Always
+status: {}
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ./docker-compose.yml
+    kompose.version: 1.20.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: watchtower
+    app: watchtower
+  name: watchtower
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: watchtower
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f ./docker-compose.yml
+        kompose.version: 1.20.0 ()
+      creationTimestamp: null
+      labels:
+        io.kompose.service: watchtower
+        app: watchtower
+    spec:
+      containers:
+      - args:
+        - --interval
+        - "59"
+        - --cleanup
+        - "true"
+        - aprsme-app
+        image: v2tec/watchtower
+        name: watchtower
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/run/docker.sock
+          name: watchtower-claim0
+      restartPolicy: Always
+      volumes:
+      - name: watchtower-claim0
+        persistentVolumeClaim:
+          claimName: watchtower-claim0
+status: {}

--- a/k8s/geoipupdate-deployment.yaml
+++ b/k8s/geoipupdate-deployment.yaml
@@ -7,11 +7,15 @@ metadata:
   creationTimestamp: null
   labels:
     io.kompose.service: geoipupdate
+    app: geoipupdate
   name: geoipupdate
 spec:
   replicas: 1
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      app: geoipupdate
   template:
     metadata:
       annotations:
@@ -21,6 +25,7 @@ spec:
       labels:
         io.kompose.network/app-tier: "true"
         io.kompose.service: geoipupdate
+        app: geoipupdate
     spec:
       containers:
       - env:

--- a/k8s/namespace-dev.yaml
+++ b/k8s/namespace-dev.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "aprsme-dev"
+  labels:
+    name: "aprsme-dev"

--- a/k8s/networkpolicy.yaml
+++ b/k8s/networkpolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: extensions/v1beta1
+kind: NetworkPolicy
+metadata:
+  creationTimestamp: null
+  name: app-tier
+spec:
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          io.kompose.network/app-tier: "true"
+  podSelector:
+    matchLabels:
+      io.kompose.network/app-tier: "true"

--- a/k8s/nginx-deployment.yaml
+++ b/k8s/nginx-deployment.yaml
@@ -7,11 +7,15 @@ metadata:
   creationTimestamp: null
   labels:
     io.kompose.service: nginx
+    app: nginx
   name: nginx
 spec:
   replicas: 1
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       annotations:
@@ -21,6 +25,7 @@ spec:
       labels:
         io.kompose.network/app-tier: "true"
         io.kompose.service: nginx
+        app: nginx
     spec:
       containers:
       - image: nginx:1.17.7-alpine

--- a/k8s/rabbitmq-deployment.yaml
+++ b/k8s/rabbitmq-deployment.yaml
@@ -7,10 +7,14 @@ metadata:
   creationTimestamp: null
   labels:
     io.kompose.service: rabbitmq
+    app: rabbitmq
   name: rabbitmq
 spec:
   replicas: 1
   strategy: {}
+  selector:
+    matchLabels:
+      app: rabbitmq
   template:
     metadata:
       annotations:
@@ -20,6 +24,7 @@ spec:
       labels:
         io.kompose.network/app-tier: "true"
         io.kompose.service: rabbitmq
+        app: rabbitmq
     spec:
       containers:
       - env:

--- a/k8s/services.yaml
+++ b/k8s/services.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ./docker-compose.yml
+    kompose.version: 1.20.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: app
+  name: app
+spec:
+  ports:
+  - name: "4000"
+    port: 4000
+    targetPort: 4000
+  selector:
+    io.kompose.service: app
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ./docker-compose.yml
+    kompose.version: 1.20.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: nginx
+  name: nginx
+spec:
+  ports:
+  - name: "80"
+    port: 80
+    targetPort: 80
+  - name: "443"
+    port: 443
+    targetPort: 443
+  selector:
+    io.kompose.service: nginx
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ./docker-compose.yml
+    kompose.version: 1.20.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: postgres
+  name: postgres
+spec:
+  ports:
+  - name: "25432"
+    port: 25432
+    targetPort: 5432
+  selector:
+    io.kompose.service: postgres
+status:
+  loadBalancer: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ./docker-compose.yml
+    kompose.version: 1.20.0 ()
+  creationTimestamp: null
+  labels:
+    io.kompose.service: rabbitmq
+  name: rabbitmq
+spec:
+  ports:
+  - name: "15672"
+    port: 15672
+    targetPort: 15672
+  - name: "5672"
+    port: 5672
+    targetPort: 5672
+  selector:
+    io.kompose.service: rabbitmq
+status:
+  loadBalancer: {}

--- a/k8s/storage.yaml
+++ b/k8s/storage.yaml
@@ -1,0 +1,134 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: app-claim0
+  name: app-claim0
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: certbot-claim0
+  name: certbot-claim0
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: certbot-claim1
+  name: certbot-claim1
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: geoipupdate-claim0
+  name: geoipupdate-claim0
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: nginx-claim0
+  name: nginx-claim0
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: nginx-claim1
+  name: nginx-claim1
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: nginx-claim2
+  name: nginx-claim2
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: postgres-claim0
+  name: postgres-claim0
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: watchtower-claim0
+  name: watchtower-claim0
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/k8s/watchtower-deployment.yaml
+++ b/k8s/watchtower-deployment.yaml
@@ -7,11 +7,15 @@ metadata:
   creationTimestamp: null
   labels:
     io.kompose.service: watchtower
+    app: watchtower
   name: watchtower
 spec:
   replicas: 1
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      app: watchtower
   template:
     metadata:
       annotations:
@@ -20,6 +24,7 @@ spec:
       creationTimestamp: null
       labels:
         io.kompose.service: watchtower
+        app: watchtower
     spec:
       containers:
       - args:


### PR DESCRIPTION
This PR creates a set of bulk manifest files to add all services, storage, and deployments in one go and also fixes to the deployment manifests to add labels and selectors.

Currently the Watchtower container does not run successfully.